### PR TITLE
Fix dhPubEq

### DIFF
--- a/src/Crypto/Noise/DH/Curve25519.hs
+++ b/src/Crypto/Noise/DH/Curve25519.hs
@@ -61,4 +61,4 @@ bytesToPair bs = do
 pubEq :: PublicKey Curve25519
       -> PublicKey Curve25519
       -> Bool
-pubEq a b = a == b
+pubEq (PK25519 a) (PK25519 b) = a == b

--- a/src/Crypto/Noise/DH/Curve448.hs
+++ b/src/Crypto/Noise/DH/Curve448.hs
@@ -61,4 +61,4 @@ bytesToPair bs = do
 pubEq :: PublicKey Curve448
       -> PublicKey Curve448
       -> Bool
-pubEq a b = a == b
+pubEq (PK448 a) (PK448 b) = a == b


### PR DESCRIPTION
I actually don't understand the root cause, how type families allows `Eq` instance to be derived without explicit `deriving` statement. But with `ghc 8.0.2` and `cacophony 0.9.2`, the following code would reach bottom (infinite loop).

~~~haskell
import Crypto.Noise.DH
import Crypto.Noise.DH.Curve25519

main :: IO ()
main = do
    key1 <- snd <$> dhGenKey :: IO (PublicKey Curve25519)
    key2 <- snd <$> dhGenKey :: IO (PublicKey Curve25519)
    print (key1 == key2)
~~~