### PR TITLE
fix Kpsk0 handshake pattern typo

### DIFF
--- a/src/Crypto/Noise/HandshakePatterns.hs
+++ b/src/Crypto/Noise/HandshakePatterns.hs
@@ -400,6 +400,7 @@ noiseNpsk0 = handshakePattern "Npsk0" $
 --  -> psk, e, es, ss@
 noiseKpsk0 :: HandshakePattern
 noiseKpsk0 = handshakePattern "Kpsk0" $
+  preInitiator s *>
   preResponder s *>
   initiator (psk *> e *> es *> ss)
 


### PR DESCRIPTION
I just updated my vector tests in https://github.com/mcginty/snow and noticed that my Noise_Kpsk0_* tests were failing the vectors generated by cacophony.

I think this was caused by what looks like a typo in section 9.4 of rev32 that leaves out the other static key premessage.

Note that I didn't commit new generated vectors because when I tried, it didn't look anything like the one already committed so the diff would be super gross. I'm just going to assume that you can regenerate them in the same fashion you did previously with little effort.
