### PR TITLE
Add lower bound on cryptonite

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -32,7 +32,7 @@ library:
   dependencies:
     - base >= 4.9 && < 4.11
     - bytestring
-    - cryptonite
+    - cryptonite >= 0.22
     - exceptions
     - free
     - lens


### PR DESCRIPTION
Version 0.22 was the first version that included the `Crypto.PubKey.Curve448` module.