### PR TITLE
Support GHC > 8.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ matrix:
     - env: ARGS=""
       compiler: ": #stack 8.0.2"
 
+    - env: ARGS="--resolver lts-11.22"
+      compiler: ": #stack 8.2.2"
+
+    - env: ARGS="--resolver lts-12.12"
+      compiler: ": #stack 8.4.3"
+
     - env: ARGS="--resolver nightly"
       compiler: ": #stack nightly"
 

--- a/package.yaml
+++ b/package.yaml
@@ -27,10 +27,12 @@ flags:
     default: False
     manual: True
 
+dependencies:
+  - base >= 4.9 && < 5
+
 library:
   source-dirs: src
   dependencies:
-    - base >= 4.9 && < 4.11
     - bytestring
     - cryptonite >= 0.22
     - exceptions
@@ -74,7 +76,6 @@ tests:
     main: hlint.hs
     source-dirs: tests/hlint
     dependencies:
-      - base >= 4.9 && < 4.11
       - hlint
 
     ghc-options:
@@ -89,7 +90,6 @@ tests:
     dependencies:
       - aeson
       - attoparsec
-      - base >= 4.9 && < 4.11
       - base16-bytestring
       - bytestring
       - cacophony
@@ -111,7 +111,6 @@ benchmarks:
     source-dirs: benchmarks
     dependencies:
       - async
-      - base >= 4.9 && < 4.11
       - base16-bytestring
       - bytestring
       - cacophony
@@ -136,7 +135,6 @@ executables:
         then:
           dependencies:
             - attoparsec
-            - base >= 4.9 && < 4.11
             - base16-bytestring
             - base64-bytestring
             - bytestring

--- a/src/Crypto/Noise.hs
+++ b/src/Crypto/Noise.hs
@@ -92,7 +92,7 @@ writeMessage msg ns = maybe
   (ns ^. nsSendingCipherState)
   where
     ctToMsg       = arr cipherTextToBytes
-    updateState   = arr $ \cs -> ns & nsSendingCipherState .~ Just cs
+    updateState   = arr $ \cs -> ns & nsSendingCipherState ?~ cs
     encryptMsg cs = (ctToMsg *** updateState) <$> encryptWithAd mempty msg cs
 
 -- | Reads a handshake or transport message and returns the embedded payload. If
@@ -115,7 +115,7 @@ readMessage ct ns = maybe
   (ns ^. nsReceivingCipherState)
   where
     ct'           = cipherBytesToText ct
-    updateState   = arr $ \cs -> ns & nsReceivingCipherState .~ Just cs
+    updateState   = arr $ \cs -> ns & nsReceivingCipherState ?~ cs
     decryptMsg cs = second updateState <$> decryptWithAd mempty ct' cs
 
 -- | Given an operation ('writeMessage' or 'readMessage'), a list of PSKs, and

--- a/src/Crypto/Noise/Internal/Handshake/Pattern.hs
+++ b/src/Crypto/Noise/Internal/Handshake/Pattern.hs
@@ -10,6 +10,7 @@ module Crypto.Noise.Internal.Handshake.Pattern where
 import Control.Applicative.Free
 import Control.Lens
 import Data.ByteString (ByteString)
+import Data.Semigroup (Semigroup(..))
 
 data Token next
   = E   next
@@ -94,6 +95,9 @@ handshakePattern protoName ms = HandshakePattern protoName hasPSK ms
     scanP (Psk _) = HasPSK True
     scanP _       = mempty
 
+instance Semigroup HasPSK where
+  (HasPSK a) <> (HasPSK b) = HasPSK $ a || b
+
 instance Monoid HasPSK where
-  mempty = HasPSK False
-  (HasPSK a) `mappend` (HasPSK b) = HasPSK $ a || b
+  mempty  = HasPSK False
+  mappend = (<>)

--- a/src/Crypto/Noise/Internal/NoiseState.hs
+++ b/src/Crypto/Noise/Internal/NoiseState.hs
@@ -76,7 +76,7 @@ resumeHandshake msg ns = case ns ^. nsHandshakeSuspension of
           -- The handshake pattern has not finished running. Save the suspension
           -- and the mutated HandshakeState and return what was yielded.
           Left (Request req resp) -> do
-            let ns' = ns & nsHandshakeSuspension .~ Just (Handshake . resp)
+            let ns' = ns & nsHandshakeSuspension ?~ (Handshake . resp)
                          & nsHandshakeState      .~ hs
             return (req, ns')
           -- The handshake pattern has finished running. Create the CipherStates.
@@ -84,10 +84,10 @@ resumeHandshake msg ns = case ns ^. nsHandshakeSuspension of
             let (cs1, cs2) = split (hs ^. hsSymmetricState)
 
                 ns'        = if hs ^. hsOpts . hoRole == InitiatorRole
-                               then ns & nsSendingCipherState   .~ Just cs1
-                                       & nsReceivingCipherState .~ Just cs2
-                               else ns & nsSendingCipherState   .~ Just cs2
-                                       & nsReceivingCipherState .~ Just cs1
+                               then ns & nsSendingCipherState   ?~ cs1
+                                       & nsReceivingCipherState ?~ cs2
+                               else ns & nsSendingCipherState   ?~ cs2
+                                       & nsReceivingCipherState ?~ cs1
 
                 ns''       = ns' & nsHandshakeState .~ hs
 


### PR DESCRIPTION
This is simply relaxing the upper bound on `base` and adding a `Semigroup` instance for `HasPSK`.